### PR TITLE
Define repository_dispatch event types for report.yml

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -2,6 +2,7 @@ name: Report
 
 on:
   repository_dispatch:
+    types: [jetpack-e2e, atomic]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -2,7 +2,7 @@ name: Report
 
 on:
   repository_dispatch:
-    types: [jetpack-e2e, atomic]
+    types: [e2e]
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
https://github.com/Automattic/jetpack/pull/21281 adds another repository_dispatch type. To make sure we are not triggering not-needed workflows, let's define the allowed types for report.yml workflow. 

This PR should be merged together with https://github.com/Automattic/jetpack/pull/21281