### PR TITLE
Add report history

### DIFF
--- a/bin/update-reports-list.js
+++ b/bin/update-reports-list.js
@@ -35,11 +35,13 @@ let json = { reports: [] };
 	};
 
 	// Create the report entry
+	const isFailed = statistic.total !== statistic.passed + statistic.skipped;
 	const report = {
 		name: reportId,
 		lastUpdate: metadata.updated_on ? metadata.updated_on : '1970-01-01',
 		statistic,
 		metadata,
+		history: isFailed ? 'F' : 'P',
 	};
 
 	console.log( report );
@@ -47,6 +49,9 @@ let json = { reports: [] };
 
 	if ( reportIndex !== -1 ) {
 		// Update the report entry in the reports list
+		if ( json.reports[ reportIndex ].history ) {
+			report.history = json.reports[ reportIndex ].history + report.history;
+		}
 		json.reports[ reportIndex ] = report;
 	} else {
 		// push new report


### PR DESCRIPTION
Store past outcomes for all reports in a new `history` property of `report` object. History will be stored as string, adding a new character ('F' for failed or 'P' for passed) for each test run in the report 