### PR TITLE
Update report generation to use report metadata

### DIFF
--- a/bin/generate-report-s3.sh
+++ b/bin/generate-report-s3.sh
@@ -22,58 +22,68 @@ SCRIPT_PATH=$(
   cd "$(dirname "${BASH_SOURCE[0]}")" || return
   pwd -P
 )
-TARGET_DIR=$REPORT_ID
-REPORTS_BASE_URL=$(jq -r '.reportDeepUrl' "$SCRIPT_PATH/../src/config.json")
-TARGET_RESULTS_PATH="$TARGET_DIR/results"
-TARGET_REPORT_PATH="$TARGET_DIR/report"
-s3_reports_path="s3://a8c-jetpack-e2e-reports/reports"
-
-# Copy new results into final results path
-echo "Creating target results dir '$TARGET_RESULTS_PATH'"
-mkdir -p "$TARGET_RESULTS_PATH"
 
 for d in "$RESULTS_PATH"/*; do
-  echo "Copy results from $d to $TARGET_RESULTS_PATH"
-  cp -R "$d/allure-results/." "$TARGET_RESULTS_PATH" || true
+  echo "Checking for report metadata in $d"
+  REPORT_ID=$(jq -r '.suite' "$d/report-metadata.json")
+  echo "Found report id: $REPORT_ID"
+  RESULTS_DIR="reports/$REPORT_ID/results"
+  echo "Creating '$RESULTS_DIR' results dir if it doesn't already exist"
+  mkdir -p "$RESULTS_DIR"
+  echo "Copy results from '$d/allure-results' to '$RESULTS_DIR'"
+  cp -R "$d/allure-results/." "$RESULTS_DIR" || true
+  echo
 done
 
-echo "Getting history from existing report"
-aws s3 cp --only-show-errors --recursive "$s3_reports_path/$REPORT_ID/report/history" "$TARGET_RESULTS_PATH/history" || true
+s3_reports_path="s3://a8c-jetpack-e2e-reports/reports"
+REPORTS_BASE_URL=$(jq -r '.reportDeepUrl' "$SCRIPT_PATH/../src/config.json")
 
-echo "Creating executor.json"
+for d in reports/*; do
+  REPORT_ID=$(basename "$d")
+  echo "Creating report '$REPORT_ID'"
+  RESULTS_PATH="$d/results"
+  REPORT_PATH="$d/report"
 
-jq -n --arg url "$REPORTS_BASE_URL" \
-  --arg reportUrl "$REPORTS_BASE_URL/$REPORT_ID/report" \
-  --arg buildName "run #$RUN_ID" \
-  '{"type":"github", "buildName":$buildName, "url":$url,"reportUrl":$reportUrl}' \
-  >"$TARGET_RESULTS_PATH/executor.json"
-cat "$TARGET_RESULTS_PATH/executor.json"
+  echo "Getting history from existing report in S3"
+  aws s3 cp --only-show-errors --recursive "$s3_reports_path/$REPORT_ID/report/history" "$RESULTS_PATH/history" || true
 
-echo "Overwriting categories.json"
-cp "$SCRIPT_PATH/categories.json" "$TARGET_RESULTS_PATH/categories.json"
+  echo "Creating executor.json"
+  jq -n --arg url "$REPORTS_BASE_URL" \
+    --arg reportUrl "$REPORTS_BASE_URL/$REPORT_ID/report" \
+    --arg buildName "run #$RUN_ID" \
+    '{"type":"github", "buildName":$buildName, "url":$url,"reportUrl":$reportUrl}' \
+    >"$RESULTS_PATH/executor.json"
+  cat "$RESULTS_PATH/executor.json"
 
-echo "Generating new report"
-allure generate --clean "$TARGET_RESULTS_PATH" --output "$TARGET_REPORT_PATH"
+  echo "Overwriting categories.json"
+  cp "$SCRIPT_PATH/categories.json" "$RESULTS_PATH/categories.json"
 
-echo "Setting report title"
-# shellcheck disable=SC2002
-cat "$TARGET_REPORT_PATH/widgets/summary.json" | jq --arg name "Test report $REPORT_ID" '.reportName|=$name' >"$TARGET_REPORT_PATH/widgets/summary.tmp"
-mv "$TARGET_REPORT_PATH/widgets/summary.tmp" "$TARGET_REPORT_PATH/widgets/summary.json"
-cat "$TARGET_REPORT_PATH/widgets/summary.json"
+  echo "Generating new report"
+  allure generate --clean "$RESULTS_PATH" --output "$REPORT_PATH"
 
-echo "Cleaning up: remove results dir $TARGET_RESULTS_PATH"
-rm -rf "$TARGET_RESULTS_PATH"
+  echo "Updating report title"
+  # shellcheck disable=SC2002
+  cat "$REPORT_PATH/widgets/summary.json" | jq --arg name "Test results for '$REPORT_ID'" '.reportName|=$name' >"$REPORT_PATH/widgets/summary.tmp"
+  mv "$REPORT_PATH/widgets/summary.tmp" "$REPORT_PATH/widgets/summary.json"
+  cat "$REPORT_PATH/widgets/summary.json"
 
-echo "Writing metadata to file"
-echo "$CLIENT_PAYLOAD" | jq --arg updateDate "$(date +"%Y-%m-%dT%H:%M:%S%z")" '. + {"updated_on":$updateDate}' >"$TARGET_DIR/metadata.json"
-cat "$TARGET_DIR/metadata.json"
+  echo "Cleaning up: remove results dir $RESULTS_PATH"
+  rm -rf "$RESULTS_PATH"
 
-echo "Minifying JSON files"
-while IFS= read -r -d '' file
-do
-  jq -c . < "$file" > "$file.min" && mv "$file.min" "$file"
-done <   <(find "$TARGET_REPORT_PATH" -name '*.json' -print0)
+  echo "Writing metadata to file"
+  echo "$CLIENT_PAYLOAD" | jq --arg updateDate "$(date +"%Y-%m-%dT%H:%M:%S%z")" '. + {"updated_on":$updateDate}' >"$d/metadata.json"
+  cat "$d/metadata.json"
 
-echo "Copying report to S3"
-aws s3 cp "$TARGET_DIR" "$s3_reports_path/$REPORT_ID" --recursive --only-show-errors
+  echo "Minifying JSON files"
+  while IFS= read -r -d '' file
+  do
+    jq -c . < "$file" > "$file.min" && mv "$file.min" "$file"
+  done <   <(find "$REPORT_PATH" -name '*.json' -print0)
+
+  echo "Copying report to S3"
+  aws s3 cp "$d" "$s3_reports_path/$REPORT_ID" --recursive --only-show-errors
+
+  echo "----------------------------------------"
+  echo
+done
 


### PR DESCRIPTION
Update the report generation to use the `report-metadata.json` file.
Linked to change in [Jetpack PR 27466](https://github.com/Automattic/jetpack/pull/27466)

Currently, all output directories under a single test were included in the same report.
With `report-metadata.json`, each folder can belong to a different report. 
