### PR TITLE
Support for multiple reports in a single run

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -22,6 +22,7 @@ jobs:
       BRANCH: ${{ github.event.client_payload.branch }}
       REPORT_NAME: ${{ github.event.client_payload.report_name }}
       CLIENT_PAYLOAD: ${{ toJson(github.event.client_payload) }}
+      LOCAL_REPORTS_PATH: reports
 
     steps:
       - name: Setup Node

--- a/bin/generate-report-s3.sh
+++ b/bin/generate-report-s3.sh
@@ -22,58 +22,68 @@ SCRIPT_PATH=$(
   cd "$(dirname "${BASH_SOURCE[0]}")" || return
   pwd -P
 )
-TARGET_DIR=$REPORT_ID
-REPORTS_BASE_URL=$(jq -r '.reportDeepUrl' "$SCRIPT_PATH/../src/config.json")
-TARGET_RESULTS_PATH="$TARGET_DIR/results"
-TARGET_REPORT_PATH="$TARGET_DIR/report"
-s3_reports_path="s3://a8c-jetpack-e2e-reports/reports"
-
-# Copy new results into final results path
-echo "Creating target results dir '$TARGET_RESULTS_PATH'"
-mkdir -p "$TARGET_RESULTS_PATH"
 
 for d in "$RESULTS_PATH"/*; do
-  echo "Copy results from $d to $TARGET_RESULTS_PATH"
-  cp -R "$d/allure-results/." "$TARGET_RESULTS_PATH" || true
+  echo "Checking for report metadata in $d"
+  REPORT_ID=$(jq -r '.suite' "$d/report-metadata.json")
+  echo "Found report id: $REPORT_ID"
+  RESULTS_DIR="reports/$REPORT_ID/results"
+  echo "Creating '$RESULTS_DIR' results dir if it doesn't already exist"
+  mkdir -p "$RESULTS_DIR"
+  echo "Copy results from '$d/allure-results' to '$RESULTS_DIR'"
+  cp -R "$d/allure-results/." "$RESULTS_DIR" || true
+  echo
 done
 
-echo "Getting history from existing report"
-aws s3 cp --only-show-errors --recursive "$s3_reports_path/$REPORT_ID/report/history" "$TARGET_RESULTS_PATH/history" || true
+s3_reports_path="s3://a8c-jetpack-e2e-reports/reports"
+REPORTS_BASE_URL=$(jq -r '.reportDeepUrl' "$SCRIPT_PATH/../src/config.json")
 
-echo "Creating executor.json"
+for d in reports/*; do
+  REPORT_ID=$(basename "$d")
+  echo "Creating report '$REPORT_ID'"
+  RESULTS_PATH="$d/results"
+  REPORT_PATH="$d/report"
 
-jq -n --arg url "$REPORTS_BASE_URL" \
-  --arg reportUrl "$REPORTS_BASE_URL/$REPORT_ID/report" \
-  --arg buildName "run #$RUN_ID" \
-  '{"type":"github", "buildName":$buildName, "url":$url,"reportUrl":$reportUrl}' \
-  >"$TARGET_RESULTS_PATH/executor.json"
-cat "$TARGET_RESULTS_PATH/executor.json"
+  echo "Getting history from existing report in S3"
+  aws s3 cp --only-show-errors --recursive "$s3_reports_path/$REPORT_ID/report/history" "$RESULTS_PATH/history" || true
 
-echo "Overwriting categories.json"
-cp "$SCRIPT_PATH/categories.json" "$TARGET_RESULTS_PATH/categories.json"
+  echo "Creating executor.json"
+  jq -n --arg url "$REPORTS_BASE_URL" \
+    --arg reportUrl "$REPORTS_BASE_URL/$REPORT_ID/report" \
+    --arg buildName "run #$RUN_ID" \
+    '{"type":"github", "buildName":$buildName, "url":$url,"reportUrl":$reportUrl}' \
+    >"$RESULTS_PATH/executor.json"
+  cat "$RESULTS_PATH/executor.json"
 
-echo "Generating new report"
-allure generate --clean "$TARGET_RESULTS_PATH" --output "$TARGET_REPORT_PATH"
+  echo "Overwriting categories.json"
+  cp "$SCRIPT_PATH/categories.json" "$RESULTS_PATH/categories.json"
 
-echo "Setting report title"
-# shellcheck disable=SC2002
-cat "$TARGET_REPORT_PATH/widgets/summary.json" | jq --arg name "Test report $REPORT_ID" '.reportName|=$name' >"$TARGET_REPORT_PATH/widgets/summary.tmp"
-mv "$TARGET_REPORT_PATH/widgets/summary.tmp" "$TARGET_REPORT_PATH/widgets/summary.json"
-cat "$TARGET_REPORT_PATH/widgets/summary.json"
+  echo "Generating new report"
+  allure generate --clean "$RESULTS_PATH" --output "$REPORT_PATH"
 
-echo "Cleaning up: remove results dir $TARGET_RESULTS_PATH"
-rm -rf "$TARGET_RESULTS_PATH"
+  echo "Updating report title"
+  # shellcheck disable=SC2002
+  cat "$REPORT_PATH/widgets/summary.json" | jq --arg name "Test results for '$REPORT_ID'" '.reportName|=$name' >"$REPORT_PATH/widgets/summary.tmp"
+  mv "$REPORT_PATH/widgets/summary.tmp" "$REPORT_PATH/widgets/summary.json"
+  cat "$REPORT_PATH/widgets/summary.json"
 
-echo "Writing metadata to file"
-echo "$CLIENT_PAYLOAD" | jq --arg updateDate "$(date +"%Y-%m-%dT%H:%M:%S%z")" '. + {"updated_on":$updateDate}' >"$TARGET_DIR/metadata.json"
-cat "$TARGET_DIR/metadata.json"
+  echo "Cleaning up: remove results dir $RESULTS_PATH"
+  rm -rf "$RESULTS_PATH"
 
-echo "Minifying JSON files"
-while IFS= read -r -d '' file
-do
-  jq -c . < "$file" > "$file.min" && mv "$file.min" "$file"
-done <   <(find "$TARGET_REPORT_PATH" -name '*.json' -print0)
+  echo "Writing metadata to file"
+  echo "$CLIENT_PAYLOAD" | jq --arg updateDate "$(date +"%Y-%m-%dT%H:%M:%S%z")" '. + {"updated_on":$updateDate}' >"$d/metadata.json"
+  cat "$d/metadata.json"
 
-echo "Copying report to S3"
-aws s3 cp "$TARGET_DIR" "$s3_reports_path/$REPORT_ID" --recursive --only-show-errors
+  echo "Minifying JSON files"
+  while IFS= read -r -d '' file
+  do
+    jq -c . < "$file" > "$file.min" && mv "$file.min" "$file"
+  done <   <(find "$REPORT_PATH" -name '*.json' -print0)
+
+  echo "Copying report to S3"
+  aws s3 cp "$d" "$s3_reports_path/$REPORT_ID" --recursive --only-show-errors
+
+  echo "----------------------------------------"
+  echo
+done
 

--- a/bin/update-errors-list.js
+++ b/bin/update-errors-list.js
@@ -4,30 +4,47 @@
  * It will read data from files in $reportID/report/data/test-cases
  */
 
-const { readS3Object, readJson, cleanError } = require( './utils' );
+const { readS3Object, readJson, cleanError, getLocalReportsPaths } = require( './utils' );
 const path = require( 'path' );
 const { PutObjectCommand } = require( '@aws-sdk/client-s3' );
 const { s3Params, s3client } = require( './s3-client' );
 
-const reportId = process.env.REPORT_ID;
-
-if ( ! reportId ) {
-	throw 'REPORT_ID env variable is not set';
-}
+const reports = getLocalReportsPaths();
+let json = { errors: [] };
 
 ( async () => {
 	// Get the existing errors list
-	const json = JSON.parse( ( await readS3Object( 'data/errors.json' ) ).toString() );
+	json = JSON.parse( ( await readS3Object( 'data/errors.json' ) ).toString() );
+
+	for ( const reportPath of reports ) {
+		await updateErrorsData(reportPath);
+	}
+
+	// Write the updated errors list locally
+	// writeJson( json, path.join( "", 'errors.json' ) );
+
+	// Upload the report to S3
+	const cmd = new PutObjectCommand( {
+		Bucket: s3Params.Bucket,
+		Key: 'data/errors.json',
+		Body: JSON.stringify( json ),
+		ContentType: 'application/json',
+	} );
+	await s3client.send( cmd );
+} )();
+
+async function updateErrorsData( reportPath ) {
+	const reportId = path.basename( reportPath );
 
 	// Get the list of failures from  report/widgets/status-chart.json
-	const status = readJson( path.join( reportId, 'report/widgets/status-chart.json' ) );
+	const status = readJson( path.join( reportPath, 'report/widgets/status-chart.json' ) );
 	const failedTests = status.filter( t => t.status === 'failed' || t.status === 'broken' );
 	console.log( `Found ${ failedTests.length } failed tests` );
 
 	for ( const test of failedTests ) {
 		console.log( `Reading ${ test.uid }` );
 		const testInfo = readJson(
-			path.join( reportId, 'report/data/test-cases', `${ test.uid }.json` )
+			path.join( reportPath, 'report/data/test-cases', `${ test.uid }.json` )
 		);
 
 		if ( ( ! testInfo.statusTrace && ! testInfo.statusMessage ) || testInfo.status === 'skipped' ) {
@@ -79,16 +96,4 @@ if ( ! reportId ) {
 	}
 
 	json.lastUpdate = new Date().toISOString();
-
-	// Write the updated errors list locally
-	// writeJson( json, path.join( reportId, 'errors.json' ) );
-
-	// Upload the report to S3
-	const cmd = new PutObjectCommand( {
-		Bucket: s3Params.Bucket,
-		Key: 'data/errors.json',
-		Body: JSON.stringify( json ),
-		ContentType: 'application/json',
-	} );
-	await s3client.send( cmd );
-} )();
+}

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -195,6 +195,24 @@ function printProgress( progress ) {
 	process.stdout.write( progress );
 }
 
+/**
+ * Find any folders in a path defined in REPORTS_PATH environment variable path and return their paths
+ *
+ * @return {*[]} array of paths
+ */
+function getLocalReportsPaths() {
+	const reportsPath = process.env.LOCAL_REPORTS_PATH;
+
+	if ( ! reportsPath ) {
+		throw 'LOCAL_REPORTS_PATH env variable is not set';
+	}
+
+	return fs
+		.readdirSync( reportsPath, { withFileTypes: true } )
+		.filter( d => d.isDirectory() )
+		.map( d => path.join(reportsPath, d.name) );
+}
+
 module.exports = {
 	getReportsDirs,
 	getFilesFromDir,
@@ -210,4 +228,5 @@ module.exports = {
 	listS3Folders,
 	removeS3Folder,
 	printProgress,
+	getLocalReportsPaths
 };


### PR DESCRIPTION
Update scripts to support generation of multiple reports from a single run.
With the changes introduced by [27466](https://github.com/Automattic/jetpack/pull/27466), each artifacts folder now has a report-metadata.json file which should contain the report id to be used.

