### PR TITLE
Replace hardcoded url with value from report metadata

### DIFF
--- a/src/components/ReportsTable.js
+++ b/src/components/ReportsTable.js
@@ -129,8 +129,8 @@ export default class ReportsTable extends React.Component {
 			reportTitle = `${ metadata.pr_title } ${ prNumber }`;
 		}
 
-		const branchUrl = `https://github.com/Automattic/jetpack/tree/${ metadata.branch }`;
-		const prUrl = `https://github.com/Automattic/jetpack/pull/${ metadata.pr_number }`;
+		const branchUrl = `https://github.com/${ metadata.repository }/tree/${ metadata.branch }`;
+		const prUrl = `https://github.com/${ metadata.repository }/pull/${ metadata.pr_number }`;
 
 		let statusIcon = faQuestion;
 		let statusClassName = 'warning';


### PR DESCRIPTION
Replace the hard-coded Automattic/jetpack repo with the one from metadata object in URLs to branches or tags