### PR TITLE
Optimise cleanup

### DIFF
--- a/bin/utils.js
+++ b/bin/utils.js
@@ -180,6 +180,16 @@ async function removeS3Folder( prefix ) {
 	}
 }
 
+async function getJSONFromS3( key, silent = false ) {
+	try {
+		const content = ( await readS3Object( key, silent ) ).toString();
+		return JSON.parse( content );
+	} catch ( err ) {
+		console.error( err );
+		return null;
+	}
+}
+
 const streamToString = stream => {
 	return new Promise( ( resolve, reject ) => {
 		const chunks = [];
@@ -210,7 +220,7 @@ function getLocalReportsPaths() {
 	return fs
 		.readdirSync( reportsPath, { withFileTypes: true } )
 		.filter( d => d.isDirectory() )
-		.map( d => path.join(reportsPath, d.name) );
+		.map( d => path.join( reportsPath, d.name ) );
 }
 
 module.exports = {
@@ -228,5 +238,6 @@ module.exports = {
 	listS3Folders,
 	removeS3Folder,
 	printProgress,
-	getLocalReportsPaths
+	getLocalReportsPaths,
+	getJSONFromS3,
 };


### PR DESCRIPTION
Check for the number of results in history of each test case before trying to clean. If no test has over 20 results, no cleanup is necessary, avoiding unnecessary calls to list and check of all test case files on S3.