### PR TITLE
Display last 10 results for each reports

### DIFF
--- a/src/components/ReportsTable.js
+++ b/src/components/ReportsTable.js
@@ -105,14 +105,14 @@ export default class ReportsTable extends React.Component {
 	}
 
 	getReportRow( report, id ) {
-		const { statistic, metadata } = report; //destructuring
+		const { statistic, metadata, history } = report; //destructuring
 		const isFailed = statistic.total !== statistic.passed + statistic.skipped;
 		return (
 			<tr key={ id }>
 				<td className={ 'reportNameCell' }>
 					{ this.getReportLinkCell( report, metadata, isFailed, statistic.total ) }
 				</td>
-				<td>{ this.getTestResultsCell( statistic ) }</td>
+				<td>{ this.getTestResultsCell( statistic ) } { this.getTestResultsHistoryCell( history ) }</td>
 				<td>{ this.getMetadataCell( report ) }</td>
 			</tr>
 		);
@@ -190,6 +190,14 @@ export default class ReportsTable extends React.Component {
 		} );
 
 		return <div>{ counts }</div>;
+	}
+
+	getTestResultsHistoryCell( history ) {
+		const formattedHistory = history.slice(-10).split('').map( ( item, id ) => {
+			const statusClass = item === 'F' ? 'failed' : 'passed';
+			return (<span key={ id } className={ `label label-status-${statusClass}` }>{ item }</span>)
+		});
+		return <div>{ formattedHistory }</div>;
 	}
 
 	getMetadataCell( report ) {


### PR DESCRIPTION
In the reports view, display the last 10 results (passed/failed) next to the last result for each report.