### PR TITLE
Reports: add VIP suite to the reports, and to Slack alerts

### DIFF
--- a/alerts/index.js
+++ b/alerts/index.js
@@ -33,6 +33,7 @@ const { weeklyReport } = require( './rules/weekly-report' );
 		consecutive_failures_jetpack_social_plugin: async () => await consecutiveFailures('jetpack-social-plugin', 5),
 		consecutive_failures_jetpack_search_plugin: async () => await consecutiveFailures('jetpack-search-plugin', 5),
 		consecutive_failures_atomic: async () => await consecutiveFailures('atomic', 5),
+		consecutive_failures_vip: async () => await consecutiveFailures('vip', 5),
 		consecutive_failures_gutenberg: async () => await consecutiveFailures('gutenberg', 5),
 		weekly_report: async () => await weeklyReport(),
 	};

--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,6 @@
 {
-	"permanent": [ "atomic", "gutenberg", "jetpack-production", "jetpack-social-plugin", "jetpack-boost-production", "jetpack-search-plugin", "jetpack-videopress-plugin" ],
-	"trunkRuns": [ "master", "trunk", "atomic", "gutenberg", "jetpack-production", "jetpack-social-plugin", "jetpack-boost-production", "jetpack-search-plugin", "jetpack-videopress-plugin" ],
+	"permanent": [ "atomic", "vip", "gutenberg", "jetpack-production", "jetpack-social-plugin", "jetpack-boost-production", "jetpack-search-plugin", "jetpack-videopress-plugin" ],
+	"trunkRuns": [ "master", "trunk", "atomic", "vip", "gutenberg", "jetpack-production", "jetpack-social-plugin", "jetpack-boost-production", "jetpack-search-plugin", "jetpack-videopress-plugin" ],
 	"ignore": [ "static", "e2e", "data" ],
 	"dataSourceURL": "https://a8c-jetpack-e2e-reports.s3.amazonaws.com",
 	"reportDeepUrl": "http://a8c-jetpack-e2e-reports.s3-website-us-east-1.amazonaws.com/reports"


### PR DESCRIPTION
## Proposed changes:

This enables a new "VIP" section in [e2e reports](https://automattic.github.io/jetpack-e2e-reports/), matching the new VIP test suite. It also triggers sending alerts whenever we have 5 consecutive failures in the test suite.

Related PR: https://github.com/Automattic/jetpack/pull/32477

