### PR TITLE
Upgrade dawidd6/action-download-artifact to v20 and filter by name

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -33,7 +33,8 @@ jobs:
 
       - name: Set environment variables safely
         env:
-          PAYLOAD: ${{ toJson(github.event.client_payload) }}
+          # inputs.client_payload for workflow_dispatch, event.client_payload for repository_dispatch
+          PAYLOAD: ${{ github.event.inputs.client_payload || toJson(github.event.client_payload) }}
         run: |
           # Use jq to safely extract values from client_payload
           echo "PR_NUMBER=$(echo "$PAYLOAD" | jq -r '.pr_number // ""')" >> $GITHUB_ENV
@@ -82,12 +83,14 @@ jobs:
         run: ./bin/wait-for-artifacts.sh
 
       - name: Download artifacts
-        uses: dawidd6/action-download-artifact@23e7b2e9aa32a408a649c4fca36dee127ff5d325 # v11
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # v20
         with:
           repo: Automattic/jetpack
           workflow: e2e-tests.yml
           workflow_conclusion: "completed"
           run_id: ${{ env.RUN_ID }}
+          name: test-output-*
+          name_is_regexp: true
           path: ../downloads
 
       - name: Generate test report


### PR DESCRIPTION
## Summary

- Upgrade `dawidd6/action-download-artifact` from v11 to v20 (pinned by SHA)
- Add `name: test-output-*` filter to skip build cache artifacts
- Fix `workflow_dispatch` payload handling so the workflow can be tested manually. Previously only [`repository_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch) payloads were parsed; [`workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) inputs were ignored.

## Context

The Report workflow has been failing at artifact download since ~April 3, which caused the [Cleanup workflow](https://github.com/Automattic/jetpack-e2e-reports/actions/workflows/cleanup.yml) to progressively delete all CTRF files from S3 (2-day retention), breaking the downstream [Airflow ETL](https://a8c.slack.com/archives/C0154RESPKQ/p1775439260566189) (`qualityops.e2e_test_results`).

**Root cause:** Automattic/jetpack#47415 (merged March 8) upgraded to `actions/upload-artifact@v7`, which introduced `archive: false` for build cache artifacts (`.tar.xz` files). `dawidd6@v11` could not handle the mix of zipped and non-zipped artifacts, causing the download step to fail.

**Fix:** Upgrade to `dawidd6@v20` (uses `@actions/artifact@6.2.1`) and add a name filter so only test output artifacts are downloaded, skipping the build cache.

## Test plan

- [x] Triggered `workflow_dispatch` on this branch with Jetpack e2e run `24003101758` ([successful run](https://github.com/Automattic/jetpack-e2e-reports/actions/runs/24018030592))
- [x] Artifact download succeeds (5 test-output artifacts downloaded, 2 build cache artifacts skipped)
- [x] CTRF report files uploaded to S3
- [x] Allure reports generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)